### PR TITLE
Print unwrapped help description and epilog

### DIFF
--- a/src/help.jl
+++ b/src/help.jl
@@ -219,7 +219,7 @@ function show(io::IO, help::Help)
     end
 
     if !isempty(help.description_text)
-        println_wrapped(io, help.description_text)
+        println(io, help.description_text)
         println(io)
     end
 
@@ -240,7 +240,7 @@ function show(io::IO, help::Help)
     end
 
     if !isempty(help.epilog_text)
-        println_wrapped(io, help.epilog_text)
+        println(io, help.epilog_text)
         println(io)
     end
 end


### PR DESCRIPTION
Addresses #5.

I quickly went through the `dev` documentation (particularly `Guide/Adding Help` and `Available Macros/Help Options` and did not see any change to make. Therefore I think this is really just these two line changes.